### PR TITLE
ci: remove # from label colors

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -10,7 +10,7 @@ const createOrAddLabelSafely = async (name: string, color: string) => {
   try {
     await danger.github.utils.createOrAddLabel({
       name,
-      color,
+      color: color.replace('#', ''),
       description: '',
     });
   } catch (error) {


### PR DESCRIPTION
I'm pretty sure this is why labels are being created without the color - I've gone with `replace` because having the `#` means IDEs like IntelliJ/WebStorm will still show their colorpickers for the actual colors.