### PR TITLE
feat: drop support for `eslint@6`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14.x, 16.x, 18.x]
-        eslint-version: [6, 7, 8]
+        eslint-version: [7, 8]
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "typescript": "^4.4.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+    "eslint": "^7.0.0 || ^8.0.0"
   },
   "packageManager": "yarn@3.2.3",
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,7 +4401,7 @@ __metadata:
     ts-node: ^10.9.1
     typescript: ^4.4.0
   peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    eslint: ^7.0.0 || ^8.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Like https://github.com/jest-community/eslint-plugin-jest/pull/1212