### PR TITLE
refactor: update internal linting rules and use `type`-based imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,8 +28,17 @@ module.exports = {
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/ban-types': 'error',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      { disallowTypeAnnotations: false, fixStyle: 'inline-type-imports' },
+    ],
+    '@typescript-eslint/no-import-type-side-effects': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     'eslint-comments/no-unused-disable': 'error',
+    'eslint-plugin/require-meta-docs-description': [
+      'error',
+      { pattern: '^(Enforce|Require|Disallow|Suggest|Prefer)' },
+    ],
     'eslint-plugin/test-case-property-ordering': 'error',
     'no-else-return': 'error',
     'no-negated-condition': 'error',
@@ -43,8 +52,9 @@ module.exports = {
     ],
     'sort-imports': ['error', { ignoreDeclarationSort: true }],
     'require-unicode-regexp': 'error',
-    // TS covers this
+    // TS covers these 2
     'n/no-missing-import': 'off',
+    'n/no-missing-require': 'off',
     'n/no-unsupported-features/es-syntax': 'off',
     'n/no-unsupported-features/es-builtins': 'error',
     'import/no-commonjs': 'error',
@@ -72,6 +82,7 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-const': ['error', { destructuring: 'all' }],
     'no-var': 'error',
+    curly: 'error',
   },
   overrides: [
     {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readdirSync } from 'fs';
 import { join, parse } from 'path';
-import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import {
   name as packageName,
   version as packageVersion,

--- a/src/rules/__tests__/prefer-to-be-array.test.ts
+++ b/src/rules/__tests__/prefer-to-be-array.test.ts
@@ -1,5 +1,5 @@
 import { TSESLint } from '@typescript-eslint/utils';
-import rule, { MessageIds, Options } from '../prefer-to-be-array';
+import rule, { type MessageIds, type Options } from '../prefer-to-be-array';
 import { espreeParser } from './test-utils';
 
 const ruleTester = new TSESLint.RuleTester({

--- a/src/rules/__tests__/prefer-to-be-object.test.ts
+++ b/src/rules/__tests__/prefer-to-be-object.test.ts
@@ -1,5 +1,5 @@
 import { TSESLint } from '@typescript-eslint/utils';
-import rule, { MessageIds, Options } from '../prefer-to-be-object';
+import rule, { type MessageIds, type Options } from '../prefer-to-be-object';
 
 const ruleTester = new TSESLint.RuleTester();
 

--- a/src/rules/prefer-to-be-array.ts
+++ b/src/rules/prefer-to-be-array.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 import {
   createRule,
   followTypeAssertionChain,

--- a/src/rules/prefer-to-be-false.ts
+++ b/src/rules/prefer-to-be-false.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 import {
   EqualityMatcher,
   createRule,

--- a/src/rules/prefer-to-be-true.ts
+++ b/src/rules/prefer-to-be-true.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 import {
   EqualityMatcher,
   createRule,

--- a/src/rules/utils/__tests__/parseJestFnCall.test.ts
+++ b/src/rules/utils/__tests__/parseJestFnCall.test.ts
@@ -1,10 +1,10 @@
-import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
-import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import { TSESLint, type TSESTree } from '@typescript-eslint/utils';
 import dedent from 'dedent';
 import { espreeParser } from '../../__tests__/test-utils';
 import {
-  ParsedJestFnCall,
-  ResolvedJestFnWithNode,
+  type ParsedJestFnCall,
+  type ResolvedJestFnWithNode,
   createRule,
   getAccessorValue,
   isSupportedAccessor,

--- a/src/rules/utils/accessors.ts
+++ b/src/rules/utils/accessors.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 
 /**
  * A `Literal` with a `value` of type `string`.

--- a/src/rules/utils/followTypeAssertionChain.ts
+++ b/src/rules/utils/followTypeAssertionChain.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, type TSESTree } from '@typescript-eslint/utils';
 
 export type MaybeTypeCast<Expression extends TSESTree.Expression> =
   | TSTypeCastExpression<Expression>

--- a/src/rules/utils/misc.ts
+++ b/src/rules/utils/misc.ts
@@ -2,16 +2,16 @@ import { parse as parsePath } from 'path';
 import {
   AST_NODE_TYPES,
   ESLintUtils,
-  TSESTree,
+  type TSESTree,
 } from '@typescript-eslint/utils';
 import { repository, version } from '../../../package.json';
 import {
-  AccessorNode,
+  type AccessorNode,
   getAccessorValue,
   isSupportedAccessor,
 } from './accessors';
 import { followTypeAssertionChain } from './followTypeAssertionChain';
-import { ParsedExpectFnCall } from './parseJestFnCall';
+import type { ParsedExpectFnCall } from './parseJestFnCall';
 
 export const createRule = ESLintUtils.RuleCreator(name => {
   const ruleName = parsePath(name).name;


### PR DESCRIPTION
This aligns us with `eslint-plugin-jest`