### PR TITLE
chore: downgrade `markdown-link-check` to a known working version

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -35,4 +35,3 @@ jobs:
         run:
           find . -name "*.md" | grep -v node_modules | grep -v CHANGELOG.md |
           xargs -n 1 yarn markdown-link-check -c markdown_link_check_config.json
-          -q

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "jest": "^29.0.0",
     "jest-runner-eslint": "^2.0.0",
     "lint-staged": "^13.0.3",
-    "markdown-link-check": "^3.10.3",
+    "markdown-link-check": "~3.12.0",
     "pinst": "^3.0.0",
     "prettier": "^3.0.0",
     "rimraf": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5047,7 +5047,7 @@ __metadata:
     jest: ^29.0.0
     jest-runner-eslint: ^2.0.0
     lint-staged: ^13.0.3
-    markdown-link-check: ^3.10.3
+    markdown-link-check: ~3.12.0
     pinst: ^3.0.0
     prettier: ^3.0.0
     rimraf: ^5.0.0
@@ -7977,7 +7977,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-link-check@npm:^3.10.3":
+"markdown-link-check@npm:~3.12.0":
   version: 3.12.2
   resolution: "markdown-link-check@npm:3.12.2"
   dependencies:


### PR DESCRIPTION
[It seems that something is broken with the latest version(s)](https://github.com/tcort/markdown-link-check/issues/369) when using a config file; in the long-run it might be best to migrate to another tool but for now this should get our CI passing.

I've also removed the `-q(uiet)` flag in CI since logs are free and that could make it easier to debug in future

Also see https://github.com/jest-community/eslint-plugin-jest/pull/1697