### PR TITLE
revert: downgrade `ariperkkio/eslint-remote-tester-run-action` action

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -28,7 +28,7 @@ jobs:
           npm run build
           npm link
           npm link eslint-plugin-jest-extended
-      - uses: AriPerkkio/eslint-remote-tester-run-action@v5
+      - uses: AriPerkkio/eslint-remote-tester-run-action@v4
         with:
           issue-title: 'Results of weekly scheduled smoke test'
           eslint-remote-tester-config: eslint-remote-tester.config.ts


### PR DESCRIPTION
Reverts jest-community/eslint-plugin-jest-extended#198 as it requires `eslint-remote-tester` v4 which in turn requires ESLint v9

Resolves #288